### PR TITLE
Implement ApproxEq from the float-cmp crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,6 +497,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1539,6 +1548,7 @@ version = "0.1.0"
 dependencies = [
  "cblas-sys",
  "criterion",
+ "float-cmp",
  "hptt",
  "intel-mkl-src",
  "itertools 0.14.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
+name = "bytemuck"
+version = "1.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f154e572231cb6ba2bd1176980827e3d5dc04cc183a75dea38109fbdd672d29"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1546,6 +1566,7 @@ dependencies = [
 name = "tetra"
 version = "0.1.0"
 dependencies = [
+ "bytemuck",
  "cblas-sys",
  "criterion",
  "float-cmp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ serde = { version = "1.0.217", optional = true }
 rand = { version = "0.9.0", optional = true }
 intel-mkl-src = { version = "0.8.1", features = ["mkl-static-ilp64-iomp"] }
 cblas-sys = "0.1.4"
+float-cmp = "0.10.0"
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ rand = { version = "0.9.0", optional = true }
 intel-mkl-src = { version = "0.8.1", features = ["mkl-static-ilp64-iomp"] }
 cblas-sys = "0.1.4"
 float-cmp = "0.10.0"
+bytemuck = { version = "1.23.2", features = ["derive"] }
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod serde;
 pub mod random;
 
 mod mkl;
+mod utils;
 
 pub use mkl::max_threads;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1039,7 +1039,7 @@ mod tests {
         let b = Tensor::new_from_flat(&b_shape, b_data, Some(Layout::RowMajor));
         let c = contract(&[], &[2, 0, 1], a, &[1, 2, 0], b);
 
-        assert_approx_eq!(&Tensor, &c, &sol, ulps = 10);
+        assert_approx_eq!(&Tensor, &c, &sol, ulps = 16);
     }
 
     #[test]
@@ -1392,6 +1392,6 @@ mod tests {
         let out1 = contract(&[5, 3, 0, 4], &[0, 1, 2, 3], b, &[5, 2, 4, 1], c);
         let out2 = contract(&[3], &[5, 4, 0], d, &[5, 3, 0, 4], out1);
 
-        assert_approx_eq!(&Tensor, &out2, &solution);
+        assert_approx_eq!(&Tensor, &out2, &solution, ulps = 32);
     }
 }

--- a/src/mkl.rs
+++ b/src/mkl.rs
@@ -102,10 +102,80 @@ pub fn max_threads() -> u32 {
 
 #[cfg(test)]
 mod tests {
+    use float_cmp::assert_approx_eq;
+
+    use crate::utils::{wrap, Complex64ApproxEq};
+
     use super::*;
 
     #[test]
-    fn test_threads_positive() {
+    fn matrix_matrix_multiplication_to_vector() {
+        let a = vec![
+            Complex64::new(2.0, 5.0),
+            Complex64::new(3.0, -1.0),
+            Complex64::new(0.0, 2.0),
+            Complex64::new(-6.0, 0.0),
+            Complex64::new(-7.0, 2.0),
+            Complex64::new(0.0, 3.0),
+        ];
+        let b = vec![Complex64::new(0.0, 5.0), Complex64::new(6.0, 8.0)];
+        let solution = vec![
+            Complex64::new(-61.0, -38.0),
+            Complex64::new(-53.0, -29.0),
+            Complex64::new(-34.0, 18.0),
+        ];
+
+        let out = matrix_matrix_multiplication(3, 2, 1, &a, &b);
+        assert_approx_eq!(&[Complex64ApproxEq], wrap(&out), wrap(&solution));
+    }
+
+    #[test]
+    fn matrix_matrix_multiplication_to_matrix() {
+        let a = vec![
+            Complex64::new(0.0, -1.0),
+            Complex64::new(1.0, 0.0),
+            Complex64::new(-1.0, -1.0),
+            Complex64::new(0.0, 1.0),
+            Complex64::new(0.0, 0.0),
+            Complex64::new(1.0, 1.0),
+        ];
+        let b = vec![
+            Complex64::new(0.0, 1.0),
+            Complex64::new(1.0, 0.0),
+            Complex64::new(-1.0, 0.0),
+            Complex64::new(0.0, -1.0),
+            Complex64::new(-1.0, 1.0),
+            Complex64::new(1.0, -1.0),
+        ];
+        let solution = vec![
+            Complex64::new(0.0, -1.0),
+            Complex64::new(-1.0, 1.0),
+            Complex64::new(1.0, 0.0),
+            Complex64::new(1.0, -2.0),
+        ];
+
+        let out = matrix_matrix_multiplication(2, 3, 2, &a, &b);
+        assert_approx_eq!(&[Complex64ApproxEq], wrap(&out), wrap(&solution));
+    }
+
+    #[test]
+    #[should_panic(expected = "Matrix A dimensions don't match data length")]
+    fn matrix_matrix_multiplication_wrong_dimension_a() {
+        let a = vec![Complex64::ONE; 4];
+        let b = vec![Complex64::ONE; 6];
+        let _ = matrix_matrix_multiplication(2, 3, 2, &a, &b);
+    }
+
+    #[test]
+    #[should_panic(expected = "Matrix B dimensions don't match data length")]
+    fn matrix_matrix_multiplication_wrong_dimension_b() {
+        let a = vec![Complex64::ONE; 4];
+        let b = vec![Complex64::ONE; 6];
+        let _ = matrix_matrix_multiplication(2, 2, 4, &a, &b);
+    }
+
+    #[test]
+    fn threads_positive() {
         let max_threads = max_threads();
         assert!(max_threads > 0);
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,9 +1,10 @@
+use bytemuck::TransparentWrapper;
 use float_cmp::{ApproxEq, F64Margin};
 use num_complex::Complex64;
 
 /// A transparent wrapper around a [`Complex64`] to provide it with an [`ApproxEq`]
 /// implementation.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, TransparentWrapper)]
 #[repr(transparent)]
 pub struct Complex64ApproxEq(Complex64);
 
@@ -14,4 +15,11 @@ impl ApproxEq for Complex64ApproxEq {
         let margin = margin.into();
         self.0.re.approx_eq(other.0.re, margin) && self.0.im.approx_eq(other.0.im, margin)
     }
+}
+
+#[cfg(test)]
+/// Converts the slice to a slice of the transparent Complex64 wrapper type that
+/// implements [`ApproxEq`].
+pub fn wrap(data: &[Complex64]) -> &[Complex64ApproxEq] {
+    Complex64ApproxEq::wrap_slice(data)
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -17,7 +17,6 @@ impl ApproxEq for Complex64ApproxEq {
     }
 }
 
-#[cfg(test)]
 /// Converts the slice to a slice of the transparent Complex64 wrapper type that
 /// implements [`ApproxEq`].
 pub fn wrap(data: &[Complex64]) -> &[Complex64ApproxEq] {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,17 @@
+use float_cmp::{ApproxEq, F64Margin};
+use num_complex::Complex64;
+
+/// A transparent wrapper around a [`Complex64`] to provide it with an [`ApproxEq`]
+/// implementation.
+#[derive(Debug, Clone, Copy)]
+#[repr(transparent)]
+pub struct Complex64ApproxEq(Complex64);
+
+impl ApproxEq for Complex64ApproxEq {
+    type Margin = F64Margin;
+
+    fn approx_eq<M: Into<Self::Margin>>(self, other: Self, margin: M) -> bool {
+        let margin = margin.into();
+        self.0.re.approx_eq(other.0.re, margin) && self.0.im.approx_eq(other.0.im, margin)
+    }
+}


### PR DESCRIPTION
This allows for easier comparison of tensors. In particular, `assert_approx_eq!` prints the two tensors if the assert fails (just like `assert_eq!`) which was not the case with `assert!(all_close(...))`